### PR TITLE
Added ignoring IntelliJ Idea Configuration Files

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -109,3 +109,8 @@ venv.bak/
 .mypy_cache/
 .dmypy.json
 dmypy.json
+
+# Various IDE Environments
+.idea/ # For IntelliJ Family (I.e. PyCharm) 
+.vscode/
+.atom/


### PR DESCRIPTION
**Reasons for making this change:**
Ignoring .idea folder allows the developer to stay sane when dealing with IntelliJ products on different workstations.
Had many issues migrating from Linux to macOS because of differentiating configuration.

https://github.com/github/gitignore/blob/master/Global/VisualStudioCode.gitignore